### PR TITLE
合并代理加速去广告

### DIFF
--- a/functions/proxy/[[path]].js
+++ b/functions/proxy/[[path]].js
@@ -1,5 +1,3 @@
-// functions/proxy/[[path]].js
-
 // --- 配置 (读取自 config.js，这里为了独立运行先定义) ---
 // 注意：在实际Pages Function环境中，我们无法直接 `import config.js`
 // 所以需要将必要的配置硬编码或通过环境变量传入。这里我们硬编码。

--- a/functions/proxy/[[path]].js
+++ b/functions/proxy/[[path]].js
@@ -1,0 +1,495 @@
+// functions/proxy/[[path]].js
+
+// --- 配置 (读取自 config.js，这里为了独立运行先定义) ---
+// 注意：在实际Pages Function环境中，我们无法直接 `import config.js`
+// 所以需要将必要的配置硬编码或通过环境变量传入。这里我们硬编码。
+const FUNCTION_CONFIG = {
+    CACHE_TTL: 86400, // 24 hours
+    MAX_RECURSION: 5,
+    FILTER_DISCONTINUITY: true, // 是否过滤M3U8中的 #EXT-X-DISCONTINUITY
+    USER_AGENTS: [
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15'
+    ],
+    DEBUG: false // 改成 true 可以在 Cloudflare Functions 日志看到更多信息
+};
+
+const MEDIA_FILE_EXTENSIONS = [
+    '.mp4', '.webm', '.mkv', '.avi', '.mov', '.wmv', '.flv', '.f4v', '.m4v', '.3gp', '.3g2', '.ts', '.mts', '.m2ts',
+    '.mp3', '.wav', '.ogg', '.aac', '.m4a', '.flac', '.wma', '.alac', '.aiff', '.opus',
+    '.jpg', '.jpeg', '.png', '.gif', '.webp', '.bmp', '.tiff', '.svg', '.avif', '.heic'
+];
+const MEDIA_CONTENT_TYPES = ['video/', 'audio/', 'image/'];
+// --- 配置结束 ---
+
+
+/**
+ * 主要的 Pages Function 处理函数
+ * 拦截发往 /proxy/* 的请求
+ */
+export async function onRequest(context) {
+    const { request, env, next, waitUntil } = context; // next 和 waitUntil 可能需要
+    const url = new URL(request.url);
+
+    // --- 辅助函数 (大部分从 workers1.js 适配过来) ---
+
+    // 输出调试日志 (需要设置 DEBUG: true)
+    function logDebug(message) {
+        if (FUNCTION_CONFIG.DEBUG) {
+            console.log(`[Proxy Func] ${message}`);
+        }
+    }
+
+    // 从请求路径中提取目标 URL
+    function getTargetUrlFromPath(pathname) {
+        // 路径格式: /proxy/经过编码的URL
+        // 例如: /proxy/https%3A%2F%2Fexample.com%2Fplaylist.m3u8
+        const encodedUrl = pathname.replace(/^\/proxy\//, '');
+        if (!encodedUrl) return null;
+        try {
+            // 解码
+            let decodedUrl = decodeURIComponent(encodedUrl);
+
+             // 简单检查解码后是否是有效的 http/https URL
+             if (!decodedUrl.match(/^https?:\/\//i)) {
+                 // 也许原始路径就没有编码？如果看起来像URL就直接用
+                 if (encodedUrl.match(/^https?:\/\//i)) {
+                     decodedUrl = encodedUrl;
+                     logDebug(`Warning: Path was not encoded but looks like URL: ${decodedUrl}`);
+                 } else {
+                    logDebug(`无效的目标URL格式 (解码后): ${decodedUrl}`);
+                    return null;
+                 }
+             }
+             return decodedUrl;
+
+        } catch (e) {
+            logDebug(`解码目标URL时出错: ${encodedUrl} - ${e.message}`);
+            return null;
+        }
+    }
+
+    // 创建标准化的响应
+    function createResponse(body, status = 200, headers = {}) {
+        const responseHeaders = new Headers(headers);
+        // 关键：添加 CORS 跨域头，允许前端 JS 访问代理后的响应
+        responseHeaders.set("Access-Control-Allow-Origin", "*"); // 允许任何来源访问
+        responseHeaders.set("Access-Control-Allow-Methods", "GET, HEAD, POST, OPTIONS"); // 允许的方法
+        responseHeaders.set("Access-Control-Allow-Headers", "*"); // 允许所有请求头
+
+        // 处理 CORS 预检请求 (OPTIONS)
+         if (request.method === "OPTIONS") {
+             return new Response(null, { headers: responseHeaders, status: 204 }); // 返回空内容和允许头
+         }
+
+        return new Response(body, { status, headers: responseHeaders });
+    }
+
+    // 创建 M3U8 类型的响应
+    function createM3u8Response(content) {
+        return createResponse(content, 200, {
+            "Content-Type": "application/vnd.apple.mpegurl", // M3U8 的标准 MIME 类型
+            "Cache-Control": `public, max-age=${FUNCTION_CONFIG.CACHE_TTL}` // 允许浏览器和CDN缓存
+        });
+    }
+
+    // 获取随机 User-Agent
+    function getRandomUserAgent() {
+        return FUNCTION_CONFIG.USER_AGENTS[Math.floor(Math.random() * FUNCTION_CONFIG.USER_AGENTS.length)];
+    }
+
+    // 获取 URL 的基础路径 (用于解析相对路径)
+    function getBaseUrl(urlStr) {
+        try {
+            const parsedUrl = new URL(urlStr);
+            const pathParts = parsedUrl.pathname.split('/');
+            pathParts.pop(); // 移除文件名部分
+            return `${parsedUrl.origin}${pathParts.join('/')}/`;
+        } catch (e) {
+            // 备用方法：找到最后一个斜杠
+            const lastSlashIndex = urlStr.lastIndexOf('/');
+            // 确保不是协议部分的斜杠 (http://)
+            return lastSlashIndex > urlStr.indexOf('://') + 2 ? urlStr.substring(0, lastSlashIndex + 1) : urlStr + '/';
+        }
+    }
+
+    // 将相对 URL 转换为绝对 URL
+    function resolveUrl(baseUrl, relativeUrl) {
+        // 如果已经是绝对 URL，直接返回
+        if (relativeUrl.match(/^https?:\/\//i)) {
+            return relativeUrl;
+        }
+        try {
+            // 使用 URL 对象来处理相对路径
+            return new URL(relativeUrl, baseUrl).toString();
+        } catch (e) {
+            logDebug(`解析 URL 失败: baseUrl=${baseUrl}, relativeUrl=${relativeUrl}, error=${e.message}`);
+            // 简单的备用方法
+            if (relativeUrl.startsWith('/')) {
+                // 处理根路径相对 URL
+                const urlObj = new URL(baseUrl);
+                return `${urlObj.origin}${relativeUrl}`;
+            }
+            // 处理同级目录相对 URL
+            return `${baseUrl}${relativeUrl}`;
+        }
+    }
+
+    // 将目标 URL 重写为内部代理路径 (/proxy/...)
+    function rewriteUrlToProxy(targetUrl) {
+        // 确保目标URL被正确编码，以便作为路径的一部分
+        return `/proxy/${encodeURIComponent(targetUrl)}`;
+    }
+
+    // 获取远程内容及其类型
+    async function fetchContentWithType(targetUrl) {
+        const headers = new Headers({
+            'User-Agent': getRandomUserAgent(),
+            'Accept': '*/*',
+            // 尝试传递一些原始请求的头信息
+            'Accept-Language': request.headers.get('Accept-Language') || 'zh-CN,zh;q=0.9,en;q=0.8',
+            'Referer': new URL(targetUrl).origin // 设置 Referer 为目标网站的域名
+        });
+
+        try {
+            // 直接请求目标 URL，不再需要中间的 worker 代理
+            logDebug(`开始直接请求: ${targetUrl}`);
+            // Cloudflare Functions 的 fetch 默认支持重定向
+            const response = await fetch(targetUrl, { headers, redirect: 'follow' });
+
+            if (!response.ok) {
+                 // 如果请求失败，尝试读取错误信息
+                 const errorBody = await response.text().catch(() => ''); // 忽略读取错误体本身的错误
+                 logDebug(`请求失败: ${response.status} ${response.statusText} - ${targetUrl}`);
+                 throw new Error(`HTTP error ${response.status}: ${response.statusText}. URL: ${targetUrl}. Body: ${errorBody.substring(0, 150)}`);
+            }
+
+            // 读取响应内容为文本
+            const content = await response.text();
+            const contentType = response.headers.get('Content-Type') || '';
+            logDebug(`请求成功: ${targetUrl}, Content-Type: ${contentType}, 内容长度: ${content.length}`);
+            return { content, contentType, responseHeaders: response.headers }; // 同时返回原始响应头
+
+        } catch (error) {
+             logDebug(`请求彻底失败: ${targetUrl}: ${error.message}`);
+            // 抛出更详细的错误
+            throw new Error(`请求目标URL失败 ${targetUrl}: ${error.message}`);
+        }
+    }
+
+    // 判断是否是 M3U8 内容
+    function isM3u8Content(content, contentType) {
+        // 检查 Content-Type
+        if (contentType && (contentType.includes('application/vnd.apple.mpegurl') || contentType.includes('application/x-mpegurl') || contentType.includes('audio/mpegurl'))) {
+            return true;
+        }
+        // 检查内容本身是否以 #EXTM3U 开头
+        return content && typeof content === 'string' && content.trim().startsWith('#EXTM3U');
+    }
+
+    // 判断是否是媒体文件 (根据扩展名和 Content-Type)
+    function isMediaFile(url, contentType) {
+        // 检查 Content-Type
+        if (contentType) {
+            for (const mediaType of MEDIA_CONTENT_TYPES) {
+                // 如果 Content-Type 以 video/ audio/ image/ 开头
+                if (contentType.toLowerCase().startsWith(mediaType)) {
+                    return true;
+                }
+            }
+        }
+        // 检查文件扩展名
+        const urlLower = url.toLowerCase();
+        for (const ext of MEDIA_FILE_EXTENSIONS) {
+            // 如果 URL 以 .ts 等结尾，或者后面紧跟着 ? (查询参数)
+            if (urlLower.endsWith(ext) || urlLower.includes(`${ext}?`)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // 处理 M3U8 中的 #EXT-X-KEY 行 (加密密钥)
+    function processKeyLine(line, baseUrl) {
+        // 替换 URI="..." 部分
+        return line.replace(/URI="([^"]+)"/, (match, uri) => {
+            const absoluteUri = resolveUrl(baseUrl, uri); // 转换为绝对 URL
+            logDebug(`处理 KEY URI: 原始='${uri}', 绝对='${absoluteUri}'`);
+            return `URI="${rewriteUrlToProxy(absoluteUri)}"`; // 重写为代理路径
+        });
+    }
+
+    // 处理 M3U8 中的 #EXT-X-MAP 行 (初始化片段)
+    function processMapLine(line, baseUrl) {
+         return line.replace(/URI="([^"]+)"/, (match, uri) => {
+             const absoluteUri = resolveUrl(baseUrl, uri);
+             logDebug(`处理 MAP URI: 原始='${uri}', 绝对='${absoluteUri}'`);
+             return `URI="${rewriteUrlToProxy(absoluteUri)}"`; // 重写为代理路径
+         });
+     }
+
+    // 处理媒体 M3U8 播放列表 (包含视频/音频片段)
+    function processMediaPlaylist(url, content) {
+        const baseUrl = getBaseUrl(url);
+        const lines = content.split('\n');
+        const output = []; // 存储处理后的行
+
+        for (let i = 0; i < lines.length; i++) {
+            const line = lines[i].trim();
+            // 保留最后的空行
+            if (!line && i === lines.length - 1) {
+                output.push(line); // 添加空行并跳过后续处理
+                continue;
+            }
+            if (!line) continue; // 跳过中间的空行
+
+            // 如果配置了过滤，则跳过 #EXT-X-DISCONTINUITY
+            if (FUNCTION_CONFIG.FILTER_DISCONTINUITY && line === '#EXT-X-DISCONTINUITY') {
+                logDebug(`过滤 Discontinuity 标记: ${url}`);
+                continue;
+            }
+            // 处理加密密钥行
+            if (line.startsWith('#EXT-X-KEY')) {
+                output.push(processKeyLine(line, baseUrl));
+                continue;
+            }
+            // 处理初始化片段行
+            if (line.startsWith('#EXT-X-MAP')) {
+                output.push(processMapLine(line, baseUrl));
+                 continue;
+            }
+             // 处理 #EXTINF (片段时长信息)，直接添加
+             if (line.startsWith('#EXTINF')) {
+                 output.push(line);
+                 continue;
+             }
+             // 处理片段 URL (不是 # 开头的行，并且非空)
+             if (!line.startsWith('#')) {
+                 const absoluteUrl = resolveUrl(baseUrl, line); // 转换成绝对 URL
+                 logDebug(`重写媒体片段: 原始='${line}', 绝对='${absoluteUrl}'`);
+                 output.push(rewriteUrlToProxy(absoluteUrl)); // 重写为代理路径
+                 continue;
+             }
+             // 其他 M3U8 标签 (#EXTM3U, #EXT-X-VERSION 等) 直接添加
+             output.push(line);
+        }
+        return output.join('\n'); // 将处理后的行合并成字符串
+    }
+
+    // 递归处理 M3U8 内容 (可能是主列表或媒体列表)
+     async function processM3u8Content(targetUrl, content, recursionDepth = 0, env) {
+         // 检查是否是主列表 (包含 #EXT-X-STREAM-INF 或 #EXT-X-MEDIA)
+         if (content.includes('#EXT-X-STREAM-INF') || content.includes('#EXT-X-MEDIA:')) {
+             logDebug(`检测到主播放列表: ${targetUrl}`);
+             return await processMasterPlaylist(targetUrl, content, recursionDepth, env);
+         }
+         // 否则，作为媒体播放列表处理
+         logDebug(`检测到媒体播放列表: ${targetUrl}`);
+         return processMediaPlaylist(targetUrl, content);
+     }
+
+    // 处理主 M3U8 播放列表 (选择合适的子 M3U8)
+    async function processMasterPlaylist(url, content, recursionDepth, env) {
+        // 防止无限递归
+        if (recursionDepth > FUNCTION_CONFIG.MAX_RECURSION) {
+            throw new Error(`处理主列表时递归层数过多 (${FUNCTION_CONFIG.MAX_RECURSION}): ${url}`);
+        }
+
+        const baseUrl = getBaseUrl(url);
+        const lines = content.split('\n');
+        let highestBandwidth = -1; // 最高带宽
+        let bestVariantUrl = '';   // 最佳子 M3U8 的 URL
+
+        // 查找最高带宽的子 M3U8
+        for (let i = 0; i < lines.length; i++) {
+            // 找到 #EXT-X-STREAM-INF 行
+            if (lines[i].startsWith('#EXT-X-STREAM-INF')) {
+                // 提取带宽信息
+                const bandwidthMatch = lines[i].match(/BANDWIDTH=(\d+)/);
+                const currentBandwidth = bandwidthMatch ? parseInt(bandwidthMatch[1], 10) : 0;
+
+                // 在下一行（或之后几行，跳过注释）找到子 M3U8 的 URI
+                 let variantUriLine = '';
+                 for (let j = i + 1; j < lines.length; j++) {
+                     const line = lines[j].trim();
+                     if (line && !line.startsWith('#')) { // 确保不是空行或注释
+                         variantUriLine = line;
+                         i = j; // 更新外层循环索引，避免重复处理
+                         break;
+                     }
+                 }
+
+                 // 如果找到 URI 且带宽更高，则更新最佳选择
+                 if (variantUriLine && currentBandwidth >= highestBandwidth) { // 使用 >= 保证至少选一个
+                     highestBandwidth = currentBandwidth;
+                     bestVariantUrl = resolveUrl(baseUrl, variantUriLine);
+                 }
+            }
+        }
+
+        // 如果没有找到带 BANDWIDTH 的，尝试查找第一个 .m3u8 链接作为备选
+         if (!bestVariantUrl) {
+             logDebug(`主列表中未找到 BANDWIDTH 或 STREAM-INF，尝试查找第一个子列表引用: ${url}`);
+             for (let i = 0; i < lines.length; i++) {
+                 const line = lines[i].trim();
+                 // 如果行不是注释，且包含 .m3u8
+                 if (line && !line.startsWith('#') && (line.endsWith('.m3u8') || line.includes('m3u8?'))) {
+                    bestVariantUrl = resolveUrl(baseUrl, line);
+                     logDebug(`备选方案：找到第一个子列表引用: ${bestVariantUrl}`);
+                     break;
+                 }
+             }
+         }
+
+        // 如果最终还是没找到子 M3U8 URL
+        if (!bestVariantUrl) {
+            logDebug(`在主列表 ${url} 中未找到任何有效的子播放列表 URL。可能格式有问题或仅包含音频/字幕。将尝试按媒体列表处理原始内容。`);
+            // 尝试将原始主列表作为媒体列表处理（可能里面直接是片段？）
+            return processMediaPlaylist(url, content);
+        }
+
+        // --- 获取并处理选中的子 M3U8 ---
+
+        // 定义缓存 Key
+        const cacheKey = `m3u8_processed:${bestVariantUrl}`; // 使用处理后的缓存键
+
+        // 检查 KV 缓存 (如果 KV 已绑定)
+        let kvNamespace = null;
+        try {
+            kvNamespace = env.LIBRETV_PROXY_KV; // 从环境获取 KV 命名空间
+        } catch (e) {
+            logDebug("KV 命名空间 'LIBRETV_PROXY_KV' 未绑定或访问出错。");
+        }
+
+        if (kvNamespace) {
+            const cachedContent = await kvNamespace.get(cacheKey);
+            if (cachedContent) {
+                logDebug(`[缓存命中] 主列表的子列表: ${bestVariantUrl}`);
+                return cachedContent; // 直接返回缓存的处理后内容
+            } else {
+                logDebug(`[缓存未命中] 主列表的子列表: ${bestVariantUrl}`);
+            }
+        }
+
+        // 缓存未命中或 KV 不可用，则请求子 M3U8
+        logDebug(`选择的子列表 (带宽: ${highestBandwidth}): ${bestVariantUrl}`);
+        const { content: variantContent, contentType: variantContentType } = await fetchContentWithType(bestVariantUrl);
+
+        // 再次确保获取到的是 M3U8
+        if (!isM3u8Content(variantContent, variantContentType)) {
+            logDebug(`获取到的子列表 ${bestVariantUrl} 不是 M3U8 内容 (类型: ${variantContentType})。可能直接是媒体文件，返回原始内容。`);
+            // 如果不是M3U8，可能是最终的媒体文件，直接返回
+            return createResponse(variantContent, 200, { 'Content-Type': variantContentType || 'application/octet-stream' });
+        }
+
+        // 递归处理获取到的子 M3U8 内容
+        const processedVariant = await processM3u8Content(bestVariantUrl, variantContent, recursionDepth + 1, env);
+
+        // 将处理结果存入 KV 缓存 (如果 KV 可用)
+        if (kvNamespace) {
+             // 使用 waitUntil 异步写入缓存，不阻塞响应返回
+             waitUntil(kvNamespace.put(cacheKey, processedVariant, { expirationTtl: FUNCTION_CONFIG.CACHE_TTL }));
+             logDebug(`已将处理后的子列表写入缓存: ${bestVariantUrl}`);
+        }
+
+        return processedVariant; // 返回处理后的子 M3U8 内容
+    }
+
+    // --- 主要请求处理逻辑 ---
+
+    try {
+        // 从请求路径中提取目标 URL
+        const targetUrl = getTargetUrlFromPath(url.pathname);
+
+        // 如果无法提取目标 URL，返回错误
+        if (!targetUrl) {
+            logDebug(`无效的代理请求路径: ${url.pathname}`);
+            return createResponse("无效的代理请求。路径应为 /proxy/<经过编码的URL>", 400);
+        }
+
+        logDebug(`收到代理请求: ${targetUrl}`);
+
+        // 定义缓存 Key (使用原始目标 URL)
+        const cacheKey = `proxy_raw:${targetUrl}`; // 使用原始内容的缓存键
+
+        // 检查 KV 缓存 (如果 KV 已绑定)
+        let kvNamespace = null;
+        try {
+            kvNamespace = env.LIBRETV_PROXY_KV;
+        } catch (e) { /* 忽略错误，表示KV不可用 */ }
+
+        if (kvNamespace) {
+            // 尝试读取缓存，这里缓存的是原始未处理的内容和头信息
+            const cachedData = await kvNamespace.get(cacheKey, { type: 'json' });
+            if (cachedData && cachedData.body && cachedData.headers) {
+                logDebug(`[缓存命中] 原始内容: ${targetUrl}`);
+                const content = cachedData.body;
+                let headers = {};
+                try { headers = JSON.parse(cachedData.headers); } catch(e){}
+                const contentType = headers['content-type'] || headers['Content-Type'] || '';
+
+                // 如果缓存的是 M3U8，需要重新处理（因为里面的链接需要是动态代理的）
+                if (isM3u8Content(content, contentType)) {
+                    logDebug(`缓存内容是 M3U8，重新处理: ${targetUrl}`);
+                    const processedM3u8 = await processM3u8Content(targetUrl, content, 0, env);
+                    // 注意：这里不再缓存处理后的 M3U8，因为 processMasterPlaylist 内部会缓存
+                    return createM3u8Response(processedM3u8);
+                } else {
+                    // 如果缓存的是其他内容，直接返回
+                    logDebug(`从缓存返回非 M3U8 内容: ${targetUrl}`);
+                    return createResponse(content, 200, new Headers(headers));
+                }
+            } else {
+                 logDebug(`[缓存未命中] 原始内容: ${targetUrl}`);
+             }
+        }
+
+        // --- 缓存未命中或 KV 不可用，执行实际请求 ---
+        const { content, contentType, responseHeaders } = await fetchContentWithType(targetUrl);
+
+        // 将获取到的原始内容存入缓存 (如果 KV 可用)
+        if (kvNamespace) {
+             const headersToCache = {};
+             responseHeaders.forEach((value, key) => { headersToCache[key.toLowerCase()] = value; }); // 转小写存入
+             const cacheValue = { body: content, headers: JSON.stringify(headersToCache) };
+             // 异步写入缓存
+             waitUntil(kvNamespace.put(cacheKey, JSON.stringify(cacheValue), { expirationTtl: FUNCTION_CONFIG.CACHE_TTL }));
+             logDebug(`已将原始内容写入缓存: ${targetUrl}`);
+        }
+
+        // 判断获取到的内容是否是 M3U8
+        if (isM3u8Content(content, contentType)) {
+            logDebug(`内容是 M3U8，开始处理: ${targetUrl}`);
+            // 是 M3U8，调用处理函数
+            const processedM3u8 = await processM3u8Content(targetUrl, content, 0, env);
+            return createM3u8Response(processedM3u8);
+        } else {
+            logDebug(`内容不是 M3U8 (类型: ${contentType})，直接返回: ${targetUrl}`);
+            // 不是 M3U8，直接返回获取到的原始内容和响应头
+            const finalHeaders = new Headers(responseHeaders); // 使用原始响应头
+            finalHeaders.set('Cache-Control', `public, max-age=${FUNCTION_CONFIG.CACHE_TTL}`); // 添加缓存控制头
+            return createResponse(content, 200, finalHeaders);
+        }
+
+    } catch (error) {
+        // 捕获处理过程中的所有错误
+        logDebug(`处理代理请求时发生严重错误: ${error.message} \n ${error.stack}`);
+        // 返回 500 服务器错误，并在响应体中包含错误信息
+        return createResponse(`代理处理错误: ${error.message}`, 500);
+    }
+}
+
+// 添加一个处理 OPTIONS 预检请求的函数 (可选但推荐)
+// Cloudflare Pages 会自动为 `onRequest` 处理 OPTIONS，但明确定义可以提供更多控制
+export async function onOptions(context) {
+    // 直接返回允许跨域的头信息
+    return new Response(null, {
+        status: 204, // No Content
+        headers: {
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Methods": "GET, HEAD, POST, OPTIONS",
+            "Access-Control-Allow-Headers": "*", // 允许所有请求头
+            "Access-Control-Max-Age": "86400", // 预检请求结果缓存一天
+        },
+    });
+}

--- a/functions/proxy/[[path]].js
+++ b/functions/proxy/[[path]].js
@@ -1,3 +1,5 @@
+// functions/proxy/[[path]].js
+
 // --- 配置 (读取自 config.js，这里为了独立运行先定义) ---
 // 注意：在实际Pages Function环境中，我们无法直接 `import config.js`
 // 所以需要将必要的配置硬编码或通过环境变量传入。这里我们硬编码。

--- a/functions/proxy/[[path]].js
+++ b/functions/proxy/[[path]].js
@@ -9,7 +9,7 @@
 // DEBUG (例如 false 或 true)
 // --- 配置结束 ---
 
-// --- 常量 (之前在 config.js 中，现在移到这里或保持不变，因为它们与代理逻辑相关) ---
+// --- 常量 (之前在 config.js 中，现在移到这里，因为它们与代理逻辑相关) ---
 const MEDIA_FILE_EXTENSIONS = [
     '.mp4', '.webm', '.mkv', '.avi', '.mov', '.wmv', '.flv', '.f4v', '.m4v', '.3gp', '.3g2', '.ts', '.mts', '.m2ts',
     '.mp3', '.wav', '.ogg', '.aac', '.m4a', '.flac', '.wma', '.alac', '.aiff', '.opus',
@@ -32,7 +32,6 @@ export async function onRequest(context) {
     const CACHE_TTL = parseInt(env.CACHE_TTL || '86400'); // 默认 24 小时
     const MAX_RECURSION = parseInt(env.MAX_RECURSION || '5'); // 默认 5 层
     // 广告过滤已移至播放器处理，代理不再执行
-    const FILTER_DISCONTINUITY = false; // 硬编码为 false
     let USER_AGENTS = [ // 提供一个基础的默认值
       'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
     ];
@@ -53,7 +52,7 @@ export async function onRequest(context) {
     // --- 配置读取结束 ---
 
 
-    // --- 辅助函数 (大部分从 workers1.js 适配过来) ---
+    // --- 辅助函数 ---
 
     // 输出调试日志 (需要设置 DEBUG: true 环境变量)
     function logDebug(message) {
@@ -269,12 +268,6 @@ export async function onRequest(context) {
                 continue;
             }
             if (!line) continue; // 跳过中间的空行
-
-            // #EXT-X-DISCONTINUITY 过滤已禁用 (FILTER_DISCONTINUITY = false)
-            // if (FILTER_DISCONTINUITY && line === '#EXT-X-DISCONTINUITY') {
-            //     logDebug(`过滤 Discontinuity 标记: ${url}`);
-            //     continue;
-            // }
 
             if (line.startsWith('#EXT-X-KEY')) {
                 output.push(processKeyLine(line, baseUrl));

--- a/js/config.js
+++ b/js/config.js
@@ -1,6 +1,8 @@
+// js/config.js
+
 // 全局常量配置
 
-const PROXY_URL = 'https://cors.zme.ink/';
+const PROXY_URL = '/proxy/'; // 使用相对路径指向内部代理功能
 const HOPLAYER_URL = 'https://hoplayer.com/index.html';
 const SEARCH_HISTORY_KEY = 'videoSearchHistory';
 const MAX_HISTORY_ITEMS = 5;
@@ -8,7 +10,7 @@ const MAX_HISTORY_ITEMS = 5;
 // 网站信息配置
 const SITE_CONFIG = {
     name: 'LibreTV',
-    url: 'https://libretv.is-an.org',
+    url: 'https://libretv.is-an.org', // 您可以改成您的实际部署地址
     description: '免费在线视频搜索与观看平台',
     logo: 'https://images.icon-icons.com/38/PNG/512/retrotv_5520.png',
     version: '1.0.0'
@@ -55,6 +57,7 @@ const API_SITES = {
         api: 'https://dbzy.com',
         name: '豆瓣资源',
     }
+    // 您可以按需添加更多源
 };
 
 // 添加聚合搜索的配置选项
@@ -69,7 +72,6 @@ const AGGREGATED_SEARCH_CONFIG = {
 // 抽象API请求配置
 const API_CONFIG = {
     search: {
-        // 修改搜索接口为返回更多详细数据（包括视频封面、简介和播放列表）
         path: '/api.php/provide/vod/?ac=videolist&wd=',
         headers: {
             'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36',
@@ -77,7 +79,6 @@ const API_CONFIG = {
         }
     },
     detail: {
-        // 修改详情接口也使用videolist接口，但是通过ID查询，减少请求次数
         path: '/api.php/provide/vod/?ac=videolist&ids=',
         headers: {
             'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36',
@@ -99,9 +100,9 @@ const PLAYER_CONFIG = {
     width: '100%',
     height: '600',
     timeout: 15000,  // 播放器加载超时时间
-    filterAds: true,  // 是否启用广告过滤
+    filterAds: true,  // 是否启用广告过滤 (这个过滤由 player.html 实现)
     autoPlayNext: true,  // 默认启用自动连播功能
-    adFilteringEnabled: true, // 默认开启分片广告过滤
+    adFilteringEnabled: true, // 默认开启分片广告过滤 (这个由 player.html 或下面的代理功能实现)
     adFilteringStorage: 'adFilteringEnabled' // 存储广告过滤设置的键名
 };
 
@@ -119,9 +120,10 @@ const SECURITY_CONFIG = {
     enableXSSProtection: true,  // 是否启用XSS保护
     sanitizeUrls: true,         // 是否清理URL
     maxQueryLength: 100,        // 最大搜索长度
-    allowedApiDomains: [        // 允许的API域名
+    allowedApiDomains: [        // （此配置在此方案中作用不大，因为代理是内部的）
         'heimuer.xyz',
         'ffzy5.tv'
+        // ... 其他您信任的API域名
     ]
 };
 
@@ -132,6 +134,28 @@ const CUSTOM_API_CONFIG = {
     testTimeout: 5000,        // 测试超时时间(毫秒)
     namePrefix: 'Custom-',    // 自定义源名称前缀
     validateUrl: true,        // 验证URL格式
-    cacheResults: true,       // 缓存测试结果
-    cacheExpiry: 5184000000   // 缓存过期时间(2个月)
+    cacheResults: true,       // 缓存测试结果 (针对 testCustomApiUrl 函数)
+    cacheExpiry: 5184000000   // 缓存过期时间(2个月) (针对 testCustomApiUrl 函数)
 };
+
+
+// --- 内部代理功能配置 (从 workers1.js 适配而来) ---
+const FUNCTION_CONFIG = {
+    CACHE_TTL: 86400,             // 缓存有效期（秒，这里是24小时）
+    MAX_RECURSION: 5,             // 处理嵌套M3U8时的最大递归层数
+    FILTER_DISCONTINUITY: true,   // 是否过滤M3U8中的 #EXT-X-DISCONTINUITY 标记
+    USER_AGENTS: [                // 访问外部资源时使用的浏览器标识
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15'
+    ],
+    DEBUG: false                  // 是否在Cloudflare控制台输出调试日志
+};
+
+// 内部代理功能需要识别的媒体文件扩展名和类型
+const MEDIA_FILE_EXTENSIONS = [
+    '.mp4', '.webm', '.mkv', '.avi', '.mov', '.wmv', '.flv', '.f4v', '.m4v', '.3gp', '.3g2', '.ts', '.mts', '.m2ts',
+    '.mp3', '.wav', '.ogg', '.aac', '.m4a', '.flac', '.wma', '.alac', '.aiff', '.opus',
+    '.jpg', '.jpeg', '.png', '.gif', '.webp', '.bmp', '.tiff', '.svg', '.avif', '.heic'
+];
+const MEDIA_CONTENT_TYPES = ['video/', 'audio/', 'image/'];
+// --- 内部代理功能配置结束 ---

--- a/js/config.js
+++ b/js/config.js
@@ -1,5 +1,3 @@
-// js/config.js
-
 // 全局常量配置
 
 const PROXY_URL = '/proxy/'; // 使用相对路径指向内部代理功能
@@ -13,7 +11,7 @@ const SITE_CONFIG = {
     url: 'https://libretv.is-an.org', // 您可以改成您的实际部署地址
     description: '免费在线视频搜索与观看平台',
     logo: 'https://images.icon-icons.com/38/PNG/512/retrotv_5520.png',
-    version: '1.0.0'
+    version: '1.0.1' // 版本号更新
 };
 
 // API站点配置
@@ -21,55 +19,61 @@ const API_SITES = {
     heimuer: {
         api: 'https://json.heimuer.xyz',
         name: '黑木耳',
-        detail: 'https://heimuer.tv'
+        detail: 'https://heimuer.tv' // 假设详情页基础 URL
     },
     ffzy: {
-        api: 'http://ffzy5.tv',
+        api: 'http://ffzy5.tv', // 注意 http
         name: '非凡影视',
-        detail: 'http://ffzy5.tv'
+        detail: 'http://ffzy5.tv' // 详情页基础 URL
     },
     tyyszy: {
         api: 'https://tyyszy.com',
         name: '天涯资源',
+        // detail: 'https://tyyszy.com' // 如果有详情页
     },
     ckzy: {
         api: 'https://www.ckzy1.com',
         name: 'CK资源',
+        // detail: 'https://www.ckzy1.com'
     },
     zy360: {
         api: 'https://360zy.com',
         name: '360资源',
+        // detail: 'https://360zy.com'
     },
     wolong: {
         api: 'https://wolongzyw.com',
         name: '卧龙资源',
+        // detail: 'https://wolongzyw.com'
     },
     cjhw: {
         api: 'https://cjhwba.com',
         name: '新华为',
+        // detail: 'https://cjhwba.com'
     },
     jisu: {
         api: 'https://jszyapi.com',
         name: '极速资源',
-        detail: 'https://jszyapi.com'
+        detail: 'https://jszyapi.com' // 详情页基础 URL
     },
     dbzy: {
         api: 'https://dbzy.com',
         name: '豆瓣资源',
+        // detail: 'https://dbzy.com'
     }
     // 您可以按需添加更多源
 };
 
 // 添加聚合搜索的配置选项
 const AGGREGATED_SEARCH_CONFIG = {
-    enabled: true,             // 是否启用聚合搜索
-    timeout: 8000,            // 单个源超时时间（毫秒）
-    maxResults: 10000,          // 最大结果数量
-    parallelRequests: true,   // 是否并行请求所有源
-    showSourceBadges: true    // 是否显示来源徽章
+    enabled: true,             // 是否启用聚合搜索 (目前通过选择 "聚合搜索" 实现)
+    timeout: 8000,            // 单个源超时时间（毫秒） - 用于 handleAggregatedSearch
+    maxResults: 10000,          // 最大结果数量 (目前未强制限制)
+    parallelRequests: true,   // 是否并行请求所有源 (handleAggregatedSearch 已实现)
+    showSourceBadges: true    // 是否显示来源徽章 (app.js 已实现)
 };
 
-// 抽象API请求配置
+// 抽象API请求配置 (这些路径通常是固定的)
 const API_CONFIG = {
     search: {
         path: '/api.php/provide/vod/?ac=videolist&wd=',
@@ -87,7 +91,7 @@ const API_CONFIG = {
     }
 };
 
-// 优化后的正则表达式模式
+// 优化后的正则表达式模式 (用于非凡/极速等直接爬取详情页的情况)
 const M3U8_PATTERN = /\$https?:\/\/[^"'\s]+?\.m3u8/g;
 
 // 添加自定义播放器URL
@@ -98,15 +102,15 @@ const PLAYER_CONFIG = {
     autoplay: true,
     allowFullscreen: true,
     width: '100%',
-    height: '600',
-    timeout: 15000,  // 播放器加载超时时间
-    filterAds: true,  // 是否启用广告过滤 (这个过滤由 player.html 实现)
-    autoPlayNext: true,  // 默认启用自动连播功能
-    adFilteringEnabled: true, // 默认开启分片广告过滤 (这个由 player.html 或下面的代理功能实现)
+    height: '600', // player.html 中通过 CSS 控制更灵活
+    timeout: 15000,  // 播放器加载超时时间 (player.html 中有类似逻辑)
+    filterAds: true,  // 是否启用广告过滤 (现在由 player.html 的逻辑和开关控制)
+    autoPlayNext: true,  // 默认启用自动连播功能 (player.html 中实现)
+    adFilteringEnabled: true, // 默认开启分片广告过滤 (player.html 中实现)
     adFilteringStorage: 'adFilteringEnabled' // 存储广告过滤设置的键名
 };
 
-// 增加错误信息本地化
+// 增加错误信息本地化 (可以在 ui.js 中使用)
 const ERROR_MESSAGES = {
     NETWORK_ERROR: '网络连接错误，请检查网络设置',
     TIMEOUT_ERROR: '请求超时，服务器响应时间过长',
@@ -115,47 +119,26 @@ const ERROR_MESSAGES = {
     UNKNOWN_ERROR: '发生未知错误，请刷新页面重试'
 };
 
-// 添加进一步安全设置
+// 添加进一步安全设置 (主要用于前端输入验证)
 const SECURITY_CONFIG = {
-    enableXSSProtection: true,  // 是否启用XSS保护
-    sanitizeUrls: true,         // 是否清理URL
-    maxQueryLength: 100,        // 最大搜索长度
-    allowedApiDomains: [        // （此配置在此方案中作用不大，因为代理是内部的）
-        'heimuer.xyz',
-        'ffzy5.tv'
-        // ... 其他您信任的API域名
-    ]
+    enableXSSProtection: true,  // 是否启用XSS保护 (体现在 app.js 处理用户输入和渲染结果时)
+    sanitizeUrls: true,         // 是否清理URL (体现在 app.js 处理用户输入和 API 结果时)
+    maxQueryLength: 100,        // 最大搜索长度 (可以在 app.js 的 search 函数中检查)
+    // allowedApiDomains 不再需要，因为所有请求都通过内部代理
 };
 
 // 添加多个自定义API源的配置
 const CUSTOM_API_CONFIG = {
     separator: ',',           // 分隔符
     maxSources: 5,            // 最大允许的自定义源数量
-    testTimeout: 5000,        // 测试超时时间(毫秒)
-    namePrefix: 'Custom-',    // 自定义源名称前缀
-    validateUrl: true,        // 验证URL格式
-    cacheResults: true,       // 缓存测试结果 (针对 testCustomApiUrl 函数)
-    cacheExpiry: 5184000000   // 缓存过期时间(2个月) (针对 testCustomApiUrl 函数)
+    testTimeout: 5000,        // 测试超时时间(毫秒) - 用于 app.js 的 testCustomApiUrl
+    namePrefix: '自定义-',    // 自定义源名称前缀 (修改为中文)
+    validateUrl: true,        // 验证URL格式 (app.js 中使用)
+    cacheResults: true,       // 缓存测试结果 (app.js 中使用 localStorage)
+    cacheExpiry: 5184000000   // 缓存过期时间(2个月) (app.js 中使用)
 };
 
 
-// --- 内部代理功能配置 (从 workers1.js 适配而来) ---
-const FUNCTION_CONFIG = {
-    CACHE_TTL: 86400,             // 缓存有效期（秒，这里是24小时）
-    MAX_RECURSION: 5,             // 处理嵌套M3U8时的最大递归层数
-    FILTER_DISCONTINUITY: true,   // 是否过滤M3U8中的 #EXT-X-DISCONTINUITY 标记
-    USER_AGENTS: [                // 访问外部资源时使用的浏览器标识
-      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15'
-    ],
-    DEBUG: false                  // 是否在Cloudflare控制台输出调试日志
-};
-
-// 内部代理功能需要识别的媒体文件扩展名和类型
-const MEDIA_FILE_EXTENSIONS = [
-    '.mp4', '.webm', '.mkv', '.avi', '.mov', '.wmv', '.flv', '.f4v', '.m4v', '.3gp', '.3g2', '.ts', '.mts', '.m2ts',
-    '.mp3', '.wav', '.ogg', '.aac', '.m4a', '.flac', '.wma', '.alac', '.aiff', '.opus',
-    '.jpg', '.jpeg', '.png', '.gif', '.webp', '.bmp', '.tiff', '.svg', '.avif', '.heic'
-];
-const MEDIA_CONTENT_TYPES = ['video/', 'audio/', 'image/'];
+// --- 内部代理功能配置已移除 ---
+// 代理功能的配置现在通过 Cloudflare Pages 的环境变量设置
 // --- 内部代理功能配置结束 ---


### PR DESCRIPTION
合并项目https://github.com/eraycc/m3u8-proxy-script，实现一次性部署代理和LibreTV
Pages部署需要配置 Cloudflare KV 存储
操作：
登录您的 Cloudflare 账号。
在左侧菜单中，找到并点击 Workers 和 Pages。
在右侧选择 KV。
点击 创建命名空间 按钮。
输入一个 命名空间名称，LIBRETV_PROXY_KV。点击 添加。
回到您的 Pages 项目 设置页面 (在 Workers 和 Pages 下找到您的项目)。
点击 设置 -> 绑定。
点击 添加。
在 变量名称 处输入 LIBRETV_PROXY_KV。
在 KV 命名空间 下拉菜单中，选择您刚刚创建的 LIBRETV_PROXY_KV。
点击 保存。
重要提示： KV 绑定可能需要您重新部署一次项目才能生效。