### PR TITLE
fix: 修复豆瓣首页图片加载失败问题

### DIFF
--- a/js/douban.js
+++ b/js/douban.js
@@ -501,6 +501,12 @@ async function fetchDoubanData(url) {
 
 // 抽取渲染豆瓣卡片的逻辑到单独函数
 function renderDoubanCards(data, container) {
+    // 预获取 auth hash，用于图片 onerror fallback 的代理 URL
+    // window.__ENV__.PASSWORD 由服务端渲染注入（SHA256 hash），始终可用
+    const authHash = (window.__ENV__?.PASSWORD)
+        || localStorage.getItem('proxyAuthHash')
+        || '';
+
     // 创建文档片段以提高性能
     const fragment = document.createDocumentFragment();
     
@@ -532,8 +538,11 @@ function renderDoubanCards(data, container) {
             // 1. 直接使用豆瓣图片URL (添加no-referrer属性)
             const originalCoverUrl = item.cover;
             
-            // 2. 也准备代理URL作为备选
-            const proxiedCoverUrl = PROXY_URL + encodeURIComponent(originalCoverUrl);
+            // 2. 也准备代理URL作为备选（附带 auth 参数避免鉴权失败）
+            const baseProxiedUrl = PROXY_URL + encodeURIComponent(originalCoverUrl);
+            const proxiedCoverUrl = authHash
+                ? baseProxiedUrl + '?auth=' + encodeURIComponent(authHash)
+                : baseProxiedUrl;
             
             // 为不同设备优化卡片布局
             card.innerHTML = `

--- a/server.mjs
+++ b/server.mjs
@@ -184,7 +184,8 @@ app.get('/proxy/:encodedUrl', async (req, res) => {
           responseType: 'stream',
           timeout: config.timeout,
           headers: {
-            'User-Agent': config.userAgent
+            'User-Agent': config.userAgent,
+            'Referer': new URL(targetUrl).origin + '/'
           }
         });
       } catch (error) {


### PR DESCRIPTION
## 问题描述

豆瓣首页推荐图片无法加载，存在两个原因：

### Bug 1：代理请求缺少 Referer 头

`server.mjs` 中代理请求只发送 `User-Agent`，但豆瓣图片服务器（`img.doubanio.com`）要求请求携带 `Referer` 头，否则返回 HTTP 418。

### Bug 2：图片 onerror fallback 缺少 auth 参数

`js/douban.js` 中豆瓣首页图片的 `<img>` 标签在加载失败时，通过 `onerror` fallback 到 `/proxy/...` 代理 URL，但该 URL 没有附带 `auth` 参数。由于 `<img>` 标签的请求不经过 JS 的 `addAuthToProxyUrl()`，导致服务端代理鉴权失败（`auth` 为 `undefined`）。

## 修复方案

### 1. `server.mjs`：代理请求添加动态 Referer 头

根据目标 URL 的 origin 自动设置 `Referer`，通用于所有代理请求（不仅限于豆瓣）。

### 2. `js/douban.js`：图片 onerror fallback 预附加 auth 参数

在 `renderDoubanCards` 中预获取密码哈希（优先从 `window.__ENV__.PASSWORD` 获取），构建代理 URL 时直接附加 `auth` 参数。

## 测试

- [x] 豆瓣首页推荐图片正常加载
- [x] 代理请求鉴权通过，无 `undefined` 错误日志
- [x] 搜索功能正常，详情页图片不受影响
- [x] 未设置 PASSWORD 的场景降级为原有行为

相关 Issue: #870